### PR TITLE
Add tests(minitest), clean-up rubocop offences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.gem
 .yardoc/
 doc/
+Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,9 @@
+require:
+  - rubocop-performance
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: no_space
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,5 @@ Layout/SpaceAroundEqualsInParameterDefault:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
+Style/SafeNavigation:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,3 +9,6 @@ Style/StringLiterals:
 
 Style/SafeNavigation:
   Enabled: false
+
+Style/NegatedIf:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: ruby
+rvm:
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
+  - ruby-head
+  
+jobs:
+  allow_failures:
+    - rvm: ruby-head
+  
+sript:
+  - ruby -Ilib:test test/*

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec

--- a/lib/sd_notify.rb
+++ b/lib/sd_notify.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "socket"
 
 # SdNotify is a pure-Ruby implementation of sd_notify(3). It can be used to

--- a/lib/sd_notify.rb
+++ b/lib/sd_notify.rb
@@ -106,7 +106,7 @@ module SdNotify
   def self.notify(state, unset_env=false)
     sock = ENV["NOTIFY_SOCKET"]
 
-    return nil unless sock
+    return nil if !sock
 
     ENV.delete("NOTIFY_SOCKET") if unset_env
 

--- a/lib/sd_notify.rb
+++ b/lib/sd_notify.rb
@@ -106,21 +106,16 @@ module SdNotify
   def self.notify(state, unset_env=false)
     sock = ENV["NOTIFY_SOCKET"]
 
-    return nil if !sock
+    return nil unless sock
 
     ENV.delete("NOTIFY_SOCKET") if unset_env
 
-    connected = false
-
     begin
-      sock = Addrinfo.unix(sock, :DGRAM).connect
-      connected = true
-      sock.close_on_exec = true
-      sock.write(state)
+      Addrinfo.unix(sock, :DGRAM).connect do |s|
+        s.write(state)
+      end
     rescue StandardError => e
       raise NotifyError, "#{e.class}: #{e.message}", e.backtrace
-    ensure
-      sock.close if connected
     end
   end
 end

--- a/lib/sd_notify.rb
+++ b/lib/sd_notify.rb
@@ -112,6 +112,7 @@ module SdNotify
 
     begin
       Addrinfo.unix(sock, :DGRAM).connect do |s|
+        s.close_on_exec = true
         s.write(state)
       end
     rescue StandardError => e

--- a/sd_notify.gemspec
+++ b/sd_notify.gemspec
@@ -12,6 +12,9 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/agis/ruby-sdnotify"
   s.license     = "MIT"
 
+  s.required_ruby_version = ">= 2.3.0"
+
+  s.add_development_dependency "minitest"
   s.add_development_dependency "rubocop"
   s.add_development_dependency "rubocop-performance"
 end

--- a/sd_notify.gemspec
+++ b/sd_notify.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |s|
   s.name        = "sd_notify"
   s.version     = "0.1.0"
@@ -9,4 +11,7 @@ Gem::Specification.new do |s|
   s.files       = ["lib/sd_notify.rb", "LICENSE", "README.md", "CHANGELOG.md"]
   s.homepage    = "https://github.com/agis/ruby-sdnotify"
   s.license     = "MIT"
+
+  s.add_development_dependency "rubocop"
+  s.add_development_dependency "rubocop-performance"
 end

--- a/sd_notify.gemspec
+++ b/sd_notify.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/agis/ruby-sdnotify"
   s.license     = "MIT"
 
-  s.required_ruby_version = ">= 2.3.0"
-
   s.add_development_dependency "minitest"
   s.add_development_dependency "rubocop"
   s.add_development_dependency "rubocop-performance"

--- a/test/sd_notify_test.rb
+++ b/test/sd_notify_test.rb
@@ -14,10 +14,11 @@ class SdNotifyTest < Minitest::Test
   def test_sd_notify_ready
     setup_socket
 
-    SdNotify.ready
+    bytes_sent = SdNotify.ready
 
     assert_equal(socket_message, "READY=1")
     assert_equal(ENV["NOTIFY_SOCKET"], @sockaddr)
+    assert_equal(bytes_sent, 7)
   end
 
   def test_sd_notify_ready_unset

--- a/test/sd_notify_test.rb
+++ b/test/sd_notify_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "sd_notify"
+require "socket"
+
+class SdNotifyTest < Minitest::Test
+  def test_nil_socket
+    ENV["NOTIFY_SOCKET"] = nil
+
+    assert_nil(SdNotify.ready)
+  end
+
+  def test_sd_notify_ready
+    setup_socket
+
+    SdNotify.ready
+
+    assert_equal(socket_message, "READY=1")
+    assert_equal(ENV["NOTIFY_SOCKET"], @sockaddr)
+  end
+
+  def test_sd_notify_ready_unset
+    setup_socket
+
+    SdNotify.ready(true)
+
+    assert_equal(socket_message, "READY=1")
+    assert_nil(ENV["NOTIFY_SOCKET"])
+  end
+
+  def teardown
+    @socket&.close
+    File.unlink(@sockaddr) if @sockaddr
+    @socket = nil
+    @sockaddr = nil
+  end
+
+  private
+
+  def setup_socket
+    ::Dir::Tmpname.create("test_socket") do |sockaddr|
+      @sockaddr = sockaddr
+      @socket = Socket.new(:UNIX, :DGRAM, 0)
+      socket_ai = Addrinfo.unix(sockaddr)
+      @socket.bind(socket_ai)
+      ENV["NOTIFY_SOCKET"] = sockaddr
+    end
+  end
+
+  def socket_message
+    @socket.recvfrom(10)[0]
+  end
+end

--- a/test/sd_notify_test.rb
+++ b/test/sd_notify_test.rb
@@ -31,7 +31,7 @@ class SdNotifyTest < Minitest::Test
   end
 
   def teardown
-    @socket&.close
+    @socket.close if @socket
     File.unlink(@sockaddr) if @sockaddr
     @socket = nil
     @sockaddr = nil


### PR DESCRIPTION
- Add Gemfile to the project
- Add rubocop with basic configuration
- Add tests that cover SdNotify.ready (and `.notify` as a consequence)
- Refactor/simplify `.notify` code a bit.

Fixes #2 

@agis What do you think of it? I tried to keep the things fairly simple.
