### PR TITLE
Fix `watchdog?`'s YARD doc to be @return

### DIFF
--- a/lib/sd_notify.rb
+++ b/lib/sd_notify.rb
@@ -59,12 +59,12 @@ module SdNotify
     notify(FDSTORE, unset_env)
   end
 
-  # @param [Boolean] true if the service manager expects watchdog keep-alive
-  #   notification messages to be sent from this process.
-  #
   # If the $WATCHDOG_USEC environment variable is set,
   # and the $WATCHDOG_PID variable is unset or set to the PID of the current
   # process
+  #
+  # @return [Boolean] true if the service manager expects watchdog keep-alive
+  #   notification messages to be sent from this process.
   #
   # @note Unlike sd_watchdog_enabled(3), this method does not mutate the
   #   environment.


### PR DESCRIPTION
I noticed this was incorrectly annotated; the `@param` should be a `@return`. 

I also noticed that the `@return` is above the text description which seemed inconsistent. I didn't make that change because I assumed that was intentional, but I can make that tweak too if you give the ok. 