### PR TITLE
Test against Ruby 3.2 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,30 @@ on:
   pull_request:
 
 jobs:
+  build_older:
+    runs-on: ubuntu-20.04
+    name: Ruby ${{ matrix.ruby }}
+    strategy:
+      matrix:
+        ruby:
+          - 2.2
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run tests
+        run: ruby -Ilib:test test/*
+
   build:
     runs-on: ubuntu-latest
     name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
         ruby:
-          - 2.2
           - 2.3
           - 2.4
           - 2.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - 2.7
           - '3.0'
           - '3.1'
+          - '3.2'
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
We'd like to test the gem against Ruby 3.2, same as https://github.com/agis/ruby-sdnotify/pull/8.
More context: We are auditing whether the gem is comaptible with Ruby 3.2 https://gitlab.com/gitlab-org/gitlab/-/issues/422365

However, in https://github.com/agis/ruby-sdnotify/pull/8, the job for 2.2 is failing. So I'd like to try dropping Ruby 2.2 from the CI list, unless maintainers want to keep it, then we can find a fix.