### PR TITLE
Adds ruby-3.3 and 3.4 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
+          - '3.4'
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### What

With this PR, we're adding `ruby-3.3` and `ruby-3.4` to test matrix.

### Why

To test and verify compatibility with newer ruby versions.